### PR TITLE
Add a couple new points on the map leaderboard view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ data/token.txt
 data/token_2.txt
 data/config.json
 backups/
+flaskTestRender*.py
+.gitignore

--- a/data/templates/leaderboard_layout.html
+++ b/data/templates/leaderboard_layout.html
@@ -1,7 +1,7 @@
 <div class="main">
 <div class="song-leaderboard leaderboard">
 		<div class="card song-card">
-			<div class="song-card-background" style="background-image: url('\@song_picture'); -webkit-filter: blur(2px);">
+			<div class="song-card-background" style="background-image: url('\@song_picture'); filter: blur(2px); -webkit-filter: blur(2px); ">
 			</div>
 			<img src="\@song_picture" style="animation-duration: \@pulse_rate;">
 
@@ -11,11 +11,15 @@
 				<span class="song-info song-mapper">\@mapper_name</span>
 				<span class="song-info song-difficulty">\@song_difficulty</span>
 				<span class="song-info song-star">\@star_rating</span>
-				<span class="song-info song-nps">\@notes_per_second nps</span>
+				<span class="song-info song-nps">
+				<!-- Note: I was originally gonna use this icon [sourced from the scoresaber country leaderboards userscript], but it didn't look good. 
+					<i class="fas fa-fire fa-fw"></i>	-->
+				NPS: <b>\@notes_per_second</b></span>
+				<span class="song-info song-bpm">BPM: <b>\@bpm</b></span>
 			</div>
 
 			<div class="right-info">
-				<div class="song-hash gradient-text">\@song_hash</div>
+				<div class="song-hash gradient-text"><a href="https://beatsaver.com/maps/\@song_hash" title="Open in BeatSaver" aria-label="Open the current map in BeatSaver">\@song_hash</a></div>
 			</div>
 		</div>
 

--- a/pages.py
+++ b/pages.py
@@ -232,7 +232,7 @@ def leaderboard_page(leaderboard_id, page):
     if star_rating == 0:
         star_rating = 'Unranked'
     else:
-        star_rating = f"Ranked - {star_rating}★"
+        star_rating = f"Ranked - <b>{star_rating}★</b>"
     leaderboard_insert = {
         'leaderboard_scores': generate_leaderboard_entries(leaderboard_data, page),
         'song_name': leaderboard_data['name'],

--- a/pages.py
+++ b/pages.py
@@ -43,9 +43,11 @@ def rebuild_args(updates):
             arg_str += arg + '=' + new_args[arg]
     return arg_str
 
-def normal_page(contents, title='Hitbloq', desc='a competitive beat saber service', image='https://hitbloq.com/static/hitbloq.png'):
+def normal_page(contents, title='Hitbloq', desc='A competitive beat saber service', image='https://hitbloq.com/static/hitbloq.png'):
     if title != 'Hitbloq':
         title = 'Hitbloq - ' + title
+    if desc != 'A competitive beat saber service':
+        desc = "Hitbloq - " + desc
 
     map_pool = get_map_pool()
     database.inc_counter('views')
@@ -219,13 +221,27 @@ def leaderboard_page(leaderboard_id, page):
     star_rating = 0
     if map_pool in leaderboard_data['star_rating']:
         star_rating = leaderboard_data['star_rating'][map_pool]
+    difficulty_mappings = {
+        'easy': 'Easy',
+        'normal': 'Normal',
+        'hard': 'Hard',
+        'expert': 'Expert',
+        'expertplus': 'Expert+',
+    } # I don't really know if there's more? I don't think so...
+    
+    if star_rating == 0:
+        star_rating = 'Unranked'
+    else:
+        star_rating = f"Ranked - {star_rating}★"
     leaderboard_insert = {
         'leaderboard_scores': generate_leaderboard_entries(leaderboard_data, page),
         'song_name': leaderboard_data['name'],
         'artist_name': leaderboard_data['artist'],
         'mapper_name': leaderboard_data['mapper'],
-        'song_difficulty': leaderboard_data['difficulty'],
-        'star_rating': str(star_rating) + '★',
+        'song_difficulty': difficulty_mappings[leaderboard_data['difficulty'].lower()],
+        'star_rating': star_rating,
+        'length': str(leaderboard_data["length"]), # What is this in? Seconds?
+        'bpm': str(leaderboard_data["bpm"]) + 'BPM',
         'notes_per_second': str(round(leaderboard_data['notes'] / leaderboard_data['length'], 2)),
         'pulse_rate': str(1 / leaderboard_data['bpm'] * 60 * 2) + 's',
         'song_picture': leaderboard_data['cover'],
@@ -233,7 +249,7 @@ def leaderboard_page(leaderboard_id, page):
         'next_page': request.path.split('?')[0] + rebuild_args({'page': str(page + 1)}),
         'last_page': request.path.split('?')[0] + rebuild_args({'page': str(max(page - 1, 0))}),
     }
-    leaderboard_html = normal_page(templates.inject('leaderboard_layout', leaderboard_insert), leaderboard_data['name'] + ' Leaderboard', 'song leaderboard for ' + leaderboard_data['name'], leaderboard_data['cover'])
+    leaderboard_html = normal_page(templates.inject('leaderboard_layout', leaderboard_insert), leaderboard_data['name'] + ' Leaderboard', 'Song leaderboard for ' + leaderboard_data['name'], leaderboard_data['cover'])
     return leaderboard_html
 
 def generate_leaderboard_entries(leaderboard_data, page):

--- a/static/css/song-leaderboard.css
+++ b/static/css/song-leaderboard.css
@@ -13,6 +13,16 @@
     padding: 1.5rem;
 	position: relative;
 	background-color: rgba(45, 53, 65, 0.5);
+	/* Added to prevent scroll bar on card */
+	overflow-y: hidden;
+	scrollbar-width: none;
+	-ms-overflow-style: none;
+}
+/* Scroll bar hack but for webkit */
+.song-card::-webkit-scrollbar {
+	width: 0px;
+	background: transparent;
+	height: 0px;
 }
 
 .song-card img {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/61445877/131955380-6aa66ce5-f83f-43b8-86e9-32f36c0422a9.png)

 - Difficulty text should be replaced by the full name instead of the short name. 
- Star ranking has been changed to show ranked status.
- BPM is now shown.
- NPS & BPM now have a distinction.
- Clicking the beatmap key now takes you to the appropriate BeatSaver page.

n.b I did not test this with an actual mongodb setup. I only tested it with a short script to put dummy data into the `pages.leaderboard_page` template.