### PR TITLE
Fix nps on leaderbords

### DIFF
--- a/new_pages.py
+++ b/new_pages.py
@@ -168,7 +168,7 @@ def leaderboard(leaderboard_id):
         'mapper': leaderboard_data['mapper'],
         'difficulty': leaderboard_data['difficulty'],
         'stars': str(star_rating) + '★ ' + (('(' + shown_name + ')') if shown_name else ''),
-        'nps': str(round(leaderboard_data['notes'] / leaderboard_data['length'], 2)),
+        'nps': str(round(leaderboard_data['notes'] / leaderboard_data['duration'], 2)),
         'key': leaderboard_data['key'],
         'hash': leaderboard_data['hash'],
         'page_left': last_page,


### PR DESCRIPTION
nps calculation currently uses the "length", which represents the number of mapped beats. "Duration" is the correct data to use here as it represents the length of the song in seconds.

Not sure if you have an easy way to update all the old leaderboards to fix the data, but this'll at least fix it going forward.